### PR TITLE
fix: permission octal being converted to decimal before setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Composer script handling directories permissions
 Run the below command to install the plugin
 
 ```
-composer require idnan/composer-permission
+composer require darkalchemy/composer-permission
 ```
 And then put the below configuration in your composer.json file
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "idnan/composer-permission",
+    "name": "darkalchemy/composer-permission",
     "description": "Composer script handling directories permissions by making them writable both",
     "keywords": [
         "composer",
@@ -17,8 +17,8 @@
         "php": ">=5.3"
     },
     "require-dev": {
-        "composer/composer": "1.0.*@dev",
-        "phpspec/phpspec": "~2.0"
+        "composer/composer": "dev-main",
+        "phpspec/phpspec": "^7.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -42,7 +42,7 @@ class Handler
             }
 
             try {
-                if (chmod($dir, $permission)) {
+                if (chmod($dir, octdec($permission))) {
                     $event->getIO()->write("Done");
                 }
             } catch (Exception $e) {


### PR DESCRIPTION
Hello,

This pr converts the string $permission to octal in order to set the correct permission.

Thanks